### PR TITLE
Change initscript ordering

### DIFF
--- a/init.d/tsds-aggregate-daemon
+++ b/init.d/tsds-aggregate-daemon
@@ -2,7 +2,7 @@
 #
 # tsds-aggregate-daemon        init file for starting up the tsds aggregate main work daemon
 #
-# chkconfig:   2345 20 80
+# chkconfig:   2345 86 14
 # description: Starts and stops the tsds aggregate daemon.
 
 # Source function library.

--- a/init.d/tsds-aggregate-workers
+++ b/init.d/tsds-aggregate-workers
@@ -2,7 +2,7 @@
 #
 # tsds-aggregate-workers        init file for starting up the tsds aggregate workers
 #
-# chkconfig:   2345 20 80
+# chkconfig:   2345 86 14
 # description: Starts and stops the tsds aggregate workers daemon.
 
 # Source function library.


### PR DESCRIPTION
As things currently stand, tsds-aggregate-daemon and tsds-aggregate-workers are started before MongoDB... which causes them to fail (they keep running, they just don't work). In the interest of having system start-up work better, this pull request changes the order in which services are started so that tsds-aggregate-\* starts _after_ MongoDB (assuming one uses the mongo\* initscripts in [GlobalNOC/tsds-services](https://github.com/GlobalNOC/tsds-services)).
